### PR TITLE
Sort and group sidebar menu

### DIFF
--- a/frontend/src/config/menu.ts
+++ b/frontend/src/config/menu.ts
@@ -2,18 +2,44 @@ import logo from '@/assets/logo.svg'
 import { Role } from '@/types'
 
 export interface MenuItem {
-  title: string
+  title?: string
   prependIcon?: string
   prependAvatar?: string
-  to: string | ((id: string | undefined) => string)
+  to?: string | ((id: string | undefined) => string)
   roles?: Role[]
+  type?: 'divider'
 }
 
 export const menu: MenuItem[] = [
   {
+    title: 'About',
+    prependIcon: 'mdi-information-outline',
+    to: '/about',
+  },
+  {
+    title: 'Blogs',
+    prependIcon: 'mdi-post-outline',
+    to: '/blogs',
+  },
+  {
+    title: 'Conversations',
+    prependIcon: 'mdi-message-text-outline',
+    to: '/conversations',
+  },
+  {
     title: 'Home',
     prependAvatar: logo,
     to: '/',
+  },
+  {
+    title: 'Photos',
+    prependIcon: 'mdi-image-multiple',
+    to: (id) => `/photos/${id}`,
+  },
+  {
+    title: 'Profiles',
+    prependIcon: 'mdi-account-group-outline',
+    to: '/profiles',
   },
   {
     title: 'Store',
@@ -21,6 +47,7 @@ export const menu: MenuItem[] = [
     to: '/developer/store',
     roles: [Role.Developer],
   },
+  { type: 'divider' },
   {
     title: 'Login',
     prependIcon: 'mdi-login',
@@ -28,10 +55,10 @@ export const menu: MenuItem[] = [
     roles: [Role.Guest],
   },
   {
-    title: 'Register',
-    prependIcon: 'mdi-account-plus',
-    to: '/register',
-    roles: [Role.Guest],
+    title: 'Notifications',
+    prependIcon: 'mdi-bell-outline',
+    to: '/notifications',
+    roles: [Role.User],
   },
   {
     title: 'Profile',
@@ -40,36 +67,12 @@ export const menu: MenuItem[] = [
     roles: [Role.User],
   },
   {
-    title: 'About',
-    prependIcon: 'mdi-information-outline',
-    to: '/about',
+    title: 'Register',
+    prependIcon: 'mdi-account-plus',
+    to: '/register',
+    roles: [Role.Guest],
   },
-  {
-    title: 'Conversations',
-    prependIcon: 'mdi-message-text-outline',
-    to: '/conversations',
-  },
-  {
-    title: 'Photos',
-    prependIcon: 'mdi-image-multiple',
-    to: (id) => `/photos/${id}`,
-  },
-  {
-    title: 'Blogs',
-    prependIcon: 'mdi-post-outline',
-    to: '/blogs',
-  },
-  {
-    title: 'Profiles',
-    prependIcon: 'mdi-account-group-outline',
-    to: '/profiles',
-  },
-  {
-    title: 'Notifications',
-    prependIcon: 'mdi-bell-outline',
-    to: '/notifications',
-    roles: [Role.User],
-  },
+  { type: 'divider' },
   {
     title: 'Error 401',
     prependIcon: 'mdi-alert-circle-outline',

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -11,7 +11,10 @@
       width="256"
     >
       <v-list nav>
-        <v-list-item v-for="item in filteredItems" :key="item.title" v-bind="item" />
+        <template v-for="(item, index) in filteredItems" :key="index">
+          <v-divider v-if="item.type === 'divider'" />
+          <v-list-item v-else v-bind="item" />
+        </template>
       </v-list>
 
       <template #append />
@@ -169,12 +172,19 @@ function logout() {
   router.push('/login')
 }
 
-const filteredItems = computed(() =>
-  filterMenuByRole(menu, currentUser.value?.role || Role.Guest).map((item) => ({
+const filteredItems = computed(() => {
+  const items = filterMenuByRole(menu, currentUser.value?.role || Role.Guest).map((item) => ({
     ...item,
     to: typeof item.to === 'function' ? item.to(currentUser.value?.id) : item.to,
   }))
-)
+
+  return items.filter((item, index, array) => {
+    if (item.type !== 'divider') return true
+    const prev = array[index - 1]
+    const next = array[index + 1]
+    return prev && prev.type !== 'divider' && next && next.type !== 'divider'
+  })
+})
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- sort sidebar entries alphabetically and group them with dividers
- render dividers in navigation drawer and filter excess separators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_68a6596edbfc83329a06c6821ac0a62f