### PR TITLE
Fix breadcrumb rendering for slugged blog routes

### DIFF
--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -135,14 +135,21 @@ const breadcrumbItems = computed(() => {
 
   for (const [index, record] of records.entries()) {
     const segment = record.path.split('/').findLast(Boolean) ?? ''
-    const title =
-      (record.meta?.breadcrumb as string | undefined) ??
-      segment
-        .replace(/[:()*]/g, '')
-        .replace(/-/g, ' ')
-        .replace(/^\w/, (c) => c.toUpperCase())
 
-    const to = router.resolve({ path: record.path, params: route.params }).path
+    const paramMatches = [...segment.matchAll(/:([^/-]+)/g)].map((m) => m[1])
+    const slugParam = paramMatches.at(-1)
+    let title =
+      (record.meta?.breadcrumb as string | undefined) ||
+      (slugParam && typeof route.params[slugParam] === 'string'
+        ? (route.params[slugParam] as string)
+        : segment)
+
+    title = title
+      .replace(/[:()*]/g, '')
+      .replace(/-/g, ' ')
+      .replace(/^\w/, (c) => c.toUpperCase())
+
+    const to = router.resolve({ name: record.name!, params: route.params }).path
 
     items.push({
       title,


### PR DESCRIPTION
## Summary
- Derive breadcrumb titles from slug route params
- Resolve breadcrumb links using route record names for correct slug paths

## Testing
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_68a6593fd0888332beb7c12dcee39825