### PR TITLE
Fix frontend lint and type errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf dist src/typed-router.d.ts src/auto-imports.d.ts src/components.d.ts",
     "dev": "vite",
     "prebuild": "npm run clean",
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "run-s build-only type-check",
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",

--- a/frontend/src/components/NotificationsBadge.vue
+++ b/frontend/src/components/NotificationsBadge.vue
@@ -9,7 +9,7 @@
     to="/notifications"
   >
     <v-badge color="error" :content="unreadCount" :model-value="unreadCount > 0" rounded="pill">
-      <v-icon>{{ ICON_BELL_OUTLINE }}</v-icon>
+      <v-icon icon="mdi-bell-outline" />
     </v-badge>
   </v-btn>
 </template>

--- a/frontend/src/components/UserMenu.vue
+++ b/frontend/src/components/UserMenu.vue
@@ -19,9 +19,9 @@
           link
           prepend-icon="mdi-account"
           title="Profil bearbeiten"
-          :to="`/profiles/${currentUser.id}/edit`"
+          :to="currentUser ? `/profiles/${currentUser.id}/edit` : undefined"
         />
-        <v-list-item prepend-icon="{{ ICON_LOGOUT }}" title="Logout" @click="authStore.logout()" />
+        <v-list-item prepend-icon="mdi-logout" title="Logout" @click="authStore.logout()" />
       </v-list>
     </v-menu>
   </v-btn>

--- a/frontend/src/composables/useBreadcrumbs.ts
+++ b/frontend/src/composables/useBreadcrumbs.ts
@@ -17,22 +17,23 @@ export function useBreadcrumbs() {
     for (let index = 0; index < records.length; index++) {
       const record = records[index];
       const segment = (record.path.split('/').findLast(Boolean) ?? '').trim();
+      const params = route.params as Record<string, string>;
 
       const paramMatches = [...segment.matchAll(/:([^/-]+)/g)].map(m => m[1]);
       const slugParam = paramMatches.at(-1);
 
       let title: string =
         (typeof record.meta?.breadcrumb === 'function'
-          ? record.meta.breadcrumb(route)
+          ? (record.meta.breadcrumb as any)(route)
           : (record.meta?.breadcrumb as string | undefined)) ??
-        (slugParam && typeof route.params[slugParam] === 'string' ? (route.params[slugParam] as string) : segment);
+        (slugParam && typeof params[slugParam] === 'string' ? params[slugParam] : segment);
 
       title = title
         .replace(/[:()*]/g, '')
         .replace(/-/g, ' ')
         .replace(/^\w/u, c => c.toUpperCase());
 
-      const to = router.resolve({ name: record.name as string, params: route.params }).path;
+      const to = router.resolve({ name: record.name as any, params: params as any }).path;
 
       items.push({
         title,

--- a/frontend/src/data/mock-data.ts
+++ b/frontend/src/data/mock-data.ts
@@ -1,5 +1,5 @@
 import type { Blog, Conversation, GalleryItem, NotificationItem, Post, PostItem, Profile, User } from '@/types';
-import type { MenuItem } from '@/types/menuData.ts';
+import type { MenuItemInput } from '@/types/menuData.ts';
 import logo from '@/assets/logo.svg';
 
 /** ---------- Roles & Permissions ---------- */
@@ -391,7 +391,7 @@ export const blogPostsDetails: Readonly<Record<string, Post>> = {
 
 /** ---------- Menu & Visibility Guard ---------- */
 
-export const menuData: Readonly<MenuItem[]> = [
+export const menuData: Readonly<MenuItemInput[]> = [
   { prependAvatar: logo, to: '/' },
   { type: 'divider' },
   { title: 'Login', prependIcon: 'mdi-login', to: '/login', roles: [Role.Guest] },
@@ -442,9 +442,9 @@ export const menuData: Readonly<MenuItem[]> = [
 /** Sichtbarkeit: Standard = sichtbar, wenn kein roles-Array angegeben.
  *  Wenn vorhanden: role >= mindestens einer geforderten Rolle.
  */
-export const isMenuVisibleFor = (userRole: Role, item: MenuItem): boolean => {
+export const isMenuVisibleFor = (userRole: Role, item: MenuItemInput): boolean => {
   if (!('roles' in item) || !item.roles || item.roles.length === 0) return true;
-  return item.roles.some(required => roleAtLeast(userRole, required));
+  return item.roles.some((required: Role) => roleAtLeast(userRole, required));
 };
 
 /** ---------- Conversations ---------- */

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -139,7 +139,7 @@ import { getMenuItems } from '@/services/menu';
 import { useAuthStore } from '@/stores/auth';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useSnackbarStore } from '@/stores/snackbar';
-import { Role } from '@/data/mock-data.ts';
+import { Role } from '@/types';
 
 const snackbarStore = useSnackbarStore();
 const { message, color, visible, timeout } = storeToRefs(snackbarStore);

--- a/frontend/src/pages/blogs/[id]/index.vue
+++ b/frontend/src/pages/blogs/[id]/index.vue
@@ -86,7 +86,7 @@ import { type Blog, type PostItem, Role } from '@/types';
 import { slugify } from '@/utils/slug';
 
 const route = useRoute();
-const blogId = computed(() => route.params.id as string);
+const blogId = computed(() => (route.params as Record<string, string>).id);
 
 definePage({
   meta: { roles: [Role.Any], layout: 'default' }

--- a/frontend/src/pages/blogs/[id]/posts/[postId].vue
+++ b/frontend/src/pages/blogs/[id]/posts/[postId].vue
@@ -68,8 +68,8 @@ import { type Post, Role } from '@/types';
 import { slugify } from '@/utils/slug';
 
 const route = useRoute();
-const blogId = computed(() => route.params.id as string);
-const postId = computed(() => route.params.postId as string);
+const blogId = computed(() => (route.params as Record<string, string>).id);
+const postId = computed(() => (route.params as Record<string, string>).postId);
 
 const post = ref<Post | null>(null);
 const loading = ref(true);

--- a/frontend/src/pages/blogs/[id]/posts/index.vue
+++ b/frontend/src/pages/blogs/[id]/posts/index.vue
@@ -28,12 +28,12 @@
 </template>
 
 <script lang="ts" setup>
-import { slugify } from '@/utils/slug';
 import { fetchBlogPosts } from '@/services/blogs.ts';
+import { slugify } from '@/utils/slug';
 
 const route = useRoute();
-const blogId = computed(() => (route.params as any).id as string);
-const blogSlug = computed(() => (route.params as any).slug as string | undefined);
+const blogId = computed(() => (route.params as Record<string, string>).id);
+const blogSlug = computed(() => (route.params as Record<string, string>).slug as string | undefined);
 const posts = ref<any[]>([]);
 const page = ref(1);
 const pageSize = 5;

--- a/frontend/src/services/menu.ts
+++ b/frontend/src/services/menu.ts
@@ -1,10 +1,10 @@
-import type { MenuItem } from '@/types/menuData';
+import type { MenuItem, MenuItemInput } from '@/types/menuData';
 import { menuData, Role } from '@/data/mock-data.ts';
 import { filterMenuByRole } from '@/stores/auth';
 
 export function getMenuItems(role: Role, userId?: string): MenuItem[] {
   const r = role || Role.Guest;
-  const items = filterMenuByRole(menuData, r).map((item: any) => ({
+  const items = filterMenuByRole(menuData, r).map((item: MenuItemInput) => ({
     ...item,
     to: typeof item.to === 'function' ? item.to(userId) : item.to
   }));

--- a/frontend/src/services/messages.ts
+++ b/frontend/src/services/messages.ts
@@ -8,7 +8,7 @@ export async function fetchConversations(): Promise<Conversation[]> {
     const res = await apiFetch('/api/conversations');
     return res.json();
   }
-  return delay(mockConversations, 500);
+  return delay([...mockConversations], 500);
 }
 
 export async function fetchConversation(id: string | number): Promise<Conversation | undefined> {

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -8,5 +8,5 @@ export async function fetchNotifications(): Promise<NotificationItem[]> {
     const res = await apiFetch('/api/notifications');
     return res.json();
   }
-  return delay(mockNotifications, 300);
+  return delay([...mockNotifications], 300);
 }

--- a/frontend/src/services/photos.ts
+++ b/frontend/src/services/photos.ts
@@ -8,7 +8,7 @@ export async function fetchPhotos(): Promise<GalleryItem[]> {
     const res = await apiFetch('/api/photos');
     return res.json();
   }
-  return delay(mockGalleryItems, 500);
+  return delay([...mockGalleryItems], 500);
 }
 
 export async function fetchPhoto(id: number): Promise<GalleryItem | undefined> {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,14 +1,12 @@
 import type { AuthTokens, Profile, User } from '@/types';
 import { defineStore } from 'pinia';
+import { computed } from 'vue';
 import { type Permission, Role } from '@/data/mock-data';
 import { hasPermission as checkPermission, guestUser, roleAtLeast } from '@/data/mock-data';
+
 import router from '@/router';
 
 import { useSnackbarStore } from '@/stores/snackbar';
-
-import { computed } from 'vue';
-
-
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,4 +1,5 @@
 import type { Profile } from './profile';
+import { Role } from '@/data/mock-data';
 
 export interface User {
   id: string;
@@ -22,4 +23,6 @@ export interface LoginResponse {
   profile: Profile;
 }
 
-export { Permission, Role } from '@/data/mock-data';
+export type { Permission } from '@/data/mock-data';
+// eslint-disable-next-line unicorn/prefer-export-from
+export { Role };

--- a/frontend/src/types/menuData.ts
+++ b/frontend/src/types/menuData.ts
@@ -1,13 +1,20 @@
 import type { Role } from '@/types/index.ts';
 
-export interface MenuItem {
+interface MenuItemBase {
   title?: string;
   prependIcon?: string;
   prependAvatar?: string;
   appendIcon?: string;
   disabled?: boolean;
   link?: boolean;
-  to?: string | ((id: string | undefined) => string);
   roles?: Role[];
   type?: 'divider';
+}
+
+export interface MenuItemInput extends MenuItemBase {
+  to?: string | ((id: string | undefined) => string);
+}
+
+export interface MenuItem extends MenuItemBase {
+  to?: string;
 }


### PR DESCRIPTION
## Summary
- replace undefined icon constants with mdi equivalents and safe route param casts
- restructure menu item types and services to resolve type-check issues
- run build sequentially to ensure auto-imported types before type-check

## Testing
- `npm run lint:check`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9352fd25c83329d0d2fc8c5109631