### PR TITLE
fix(frontend): correct breadcrumbs across pages

### DIFF
--- a/frontend/src/composables/useBreadcrumbs.ts
+++ b/frontend/src/composables/useBreadcrumbs.ts
@@ -10,7 +10,10 @@ export function useBreadcrumbs() {
   // --- Reactive Data Fetching with Vue Query ---
 
   const profileId = computed<string | undefined>(() => {
-    if (route.path.includes('/profiles/') && typeof (route.params as any).id === 'string') {
+    if (
+      (route.path.includes('/profiles/') || route.path.includes('/photos/')) &&
+      typeof (route.params as any).id === 'string'
+    ) {
       return (route.params as any).id as string;
     }
     return undefined;
@@ -61,6 +64,10 @@ export function useBreadcrumbs() {
       { title: 'Dina', disabled: false, to: '/' }
     ];
 
+    if (route.path.startsWith('/photos/')) {
+      items.push({ title: 'Fotos', disabled: false });
+    }
+
     for (const record of route.matched) {
       if (record.path === '/') continue;
 
@@ -81,12 +88,7 @@ export function useBreadcrumbs() {
 
       // Simple title case for non-dynamic segments
       if (!titleMeta && !record.path.includes(':')) {
-        title = record.path
-          .split('/')
-          .filter(Boolean)
-          .at(-1)
-          ?.replace(/-/g, ' ')
-          ?? '';
+        title = record.path.split('/').findLast(Boolean)?.replace(/-/g, ' ') ?? '';
         title = title.charAt(0).toUpperCase() + title.slice(1);
       }
 

--- a/frontend/src/pages/blogs/[id]/edit.vue
+++ b/frontend/src/pages/blogs/[id]/edit.vue
@@ -18,7 +18,7 @@ import { Role } from '@/types';
 import { slugify } from '@/utils/slug';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Blog bearbeiten' }
 });
 
 const auth = useAuthStore();

--- a/frontend/src/pages/blogs/[id]/posts/[postId]/edit.vue
+++ b/frontend/src/pages/blogs/[id]/posts/[postId]/edit.vue
@@ -18,7 +18,7 @@ import { Role } from '@/types';
 import { slugify } from '@/utils/slug';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Beitrag bearbeiten' }
 });
 
 const auth = useAuthStore();

--- a/frontend/src/pages/blogs/[id]/posts/index.vue
+++ b/frontend/src/pages/blogs/[id]/posts/index.vue
@@ -31,11 +31,16 @@
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useBlogPosts } from '@/services/blogs.ts';
+import { Role } from '@/types';
 import { slugify } from '@/utils/slug';
 
 const route = useRoute();
 const blogId = computed(() => (route.params as Record<string, string>).id);
 const blogSlug = computed(() => (route.params as Record<string, string>).slug as string | undefined);
+
+definePage({
+  meta: { roles: [Role.Any], layout: 'default', breadcrumb: 'Beiträge' }
+});
 
 const { data: posts, isLoading: loading } = useBlogPosts(blogId.value);
 

--- a/frontend/src/pages/blogs/[id]/posts/new.vue
+++ b/frontend/src/pages/blogs/[id]/posts/new.vue
@@ -15,7 +15,7 @@ import { useAuthStore } from '@/stores/auth';
 import { Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Neuer Beitrag' }
 });
 
 const auth = useAuthStore();

--- a/frontend/src/pages/conversations/[conversationId]/[messageId].vue
+++ b/frontend/src/pages/conversations/[conversationId]/[messageId].vue
@@ -19,7 +19,7 @@ import { useMessage } from '@/services/messages';
 import { Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Message' }
 });
 
 const route = useRoute();

--- a/frontend/src/pages/conversations/[conversationId]/index.vue
+++ b/frontend/src/pages/conversations/[conversationId]/index.vue
@@ -26,7 +26,7 @@ import { useConversation } from '@/services/messages';
 import { type ConversationId, Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Conversation' }
 });
 
 const route = useRoute();

--- a/frontend/src/pages/conversations/index.vue
+++ b/frontend/src/pages/conversations/index.vue
@@ -227,7 +227,7 @@ import { useConversations } from '@/services/messages';
 import { type Conversation, type Message, Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Messages' }
 });
 
 const { mdAndUp } = useDisplay();

--- a/frontend/src/pages/developer/croptest.vue
+++ b/frontend/src/pages/developer/croptest.vue
@@ -21,7 +21,7 @@
 import { Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.Developer], layout: 'default' }
+  meta: { roles: [Role.Developer], layout: 'default', breadcrumb: 'Cropper' }
 });
 
 function onCropped(p: { blob: Blob; dataUrl: string; width: number; height: number }) {

--- a/frontend/src/pages/developer/store.vue
+++ b/frontend/src/pages/developer/store.vue
@@ -47,7 +47,7 @@ import { useNotificationsStore } from '@/stores/notifications';
 import { Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.Developer], layout: 'default' }
+  meta: { roles: [Role.Developer], layout: 'default', breadcrumb: 'Store' }
 });
 
 const authStore = useAuthStore();

--- a/frontend/src/pages/error/401.vue
+++ b/frontend/src/pages/error/401.vue
@@ -15,6 +15,6 @@
 
 <script setup lang="ts">
 definePage({
-  meta: { layout: 'empty' }
+  meta: { layout: 'empty', breadcrumb: '401' }
 });
 </script>

--- a/frontend/src/pages/error/403.vue
+++ b/frontend/src/pages/error/403.vue
@@ -15,6 +15,6 @@
 
 <script setup lang="ts">
 definePage({
-  meta: { layout: 'empty' }
+  meta: { layout: 'empty', breadcrumb: '403' }
 });
 </script>

--- a/frontend/src/pages/error/404.vue
+++ b/frontend/src/pages/error/404.vue
@@ -15,6 +15,6 @@
 
 <script setup lang="ts">
 definePage({
-  meta: { layout: 'empty' }
+  meta: { layout: 'empty', breadcrumb: '404' }
 });
 </script>

--- a/frontend/src/pages/error/500.vue
+++ b/frontend/src/pages/error/500.vue
@@ -15,6 +15,6 @@
 
 <script setup lang="ts">
 definePage({
-  meta: { layout: 'empty' }
+  meta: { layout: 'empty', breadcrumb: '500' }
 });
 </script>

--- a/frontend/src/pages/notifications/index.vue
+++ b/frontend/src/pages/notifications/index.vue
@@ -30,7 +30,7 @@ import { Role } from '@/types';
 import { sanitize } from '@/utils/sanitize';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Benachrichtigungen' }
 });
 
 const notificationsStore = useNotificationsStore();

--- a/frontend/src/pages/profiles/[id]/edit.vue
+++ b/frontend/src/pages/profiles/[id]/edit.vue
@@ -112,7 +112,7 @@ import { useAuthStore } from '@/stores/auth';
 import { Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.User], layout: 'default' }
+  meta: { roles: [Role.User], layout: 'default', breadcrumb: 'Profil bearbeiten' }
 });
 
 const authStore = useAuthStore();

--- a/frontend/src/pages/profiles/[id]/notifications.vue
+++ b/frontend/src/pages/profiles/[id]/notifications.vue
@@ -30,7 +30,7 @@ import { Role } from '@/types';
 import { sanitize } from '@/utils/sanitize';
 
 definePage({
-  meta: { roles: [Role.Administrator], layout: 'default' }
+  meta: { roles: [Role.Administrator], layout: 'default', breadcrumb: 'Benachrichtigungen' }
 });
 
 const route = useRoute();

--- a/frontend/src/pages/profiles/index.vue
+++ b/frontend/src/pages/profiles/index.vue
@@ -73,7 +73,7 @@ import { useProfiles } from '@/services/profiles';
 import { type Profile, Role } from '@/types';
 
 definePage({
-  meta: { roles: [Role.Any], layout: 'default' }
+  meta: { roles: [Role.Any], layout: 'default', breadcrumb: 'Community' }
 });
 
 // --- State ---


### PR DESCRIPTION
## Summary
- include photo routes in breadcrumb generation
- add explicit breadcrumb labels for community, messaging, and other pages

## Testing
- `npm run lint`
- `npm run build:ci`
- `./mvnw test` *(fails: Tests run: 1, Failures: 0, Errors: 1, Skipped: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68b22277cae88332b0939c0312cc43cc