### PR TITLE
fix(frontend): use text logo for navigation and breadcrumbs

### DIFF
--- a/frontend/src/components/AppBreadcrumbs.vue
+++ b/frontend/src/components/AppBreadcrumbs.vue
@@ -1,14 +1,26 @@
 <template>
   <!-- Inherits classes/attrs (e.g., ms-2) from parent -->
-  <v-breadcrumbs :items="items" v-bind="$attrs" />
+  <v-breadcrumbs :items="items" v-bind="$attrs">
+    <template #title="{ item, index }">
+      <img v-if="index === 0" alt="Dina" class="app-breadcrumb-logo" :src="textLogo" />
+      <span v-else>{{ item.title }}</span>
+    </template>
+  </v-breadcrumbs>
   <!-- If you prefer to hide when empty, replace with:
   <v-breadcrumbs v-if="items.length" :items="items" v-bind="$attrs" />
   -->
 </template>
 
 <script setup lang="ts">
+import textLogo from '@/assets/medina-text-logo.webp';
 import { useBreadcrumbs } from '@/composables/useBreadcrumbs';
 
 const { breadcrumbItems } = useBreadcrumbs();
 const items = breadcrumbItems;
 </script>
+
+<style scoped>
+.app-breadcrumb-logo {
+  height: 20px;
+}
+</style>

--- a/frontend/src/composables/useBreadcrumbs.ts
+++ b/frontend/src/composables/useBreadcrumbs.ts
@@ -6,6 +6,7 @@ import { useProfile } from '@/services/profiles';
 export function useBreadcrumbs() {
   const route = useRoute();
   const nameCache = ref<Record<string, string>>({});
+  const labelMap: Record<string, string> = { photos: 'Fotos' };
 
   // --- Reactive Data Fetching with Vue Query ---
 
@@ -61,7 +62,7 @@ export function useBreadcrumbs() {
 
   const breadcrumbItems = computed(() => {
     const items: Array<{ title: string; disabled: boolean; to?: string }> = [
-      { title: 'Dina', disabled: false, to: '/' }
+      { title: 'Home', disabled: false, to: '/' }
     ];
 
     if (route.path.startsWith('/photos/')) {
@@ -92,18 +93,28 @@ export function useBreadcrumbs() {
         title = title.charAt(0).toUpperCase() + title.slice(1);
       }
 
+      const mapped = labelMap[title.toLowerCase()];
+      if (mapped) title = mapped;
+
       items.push({
         title,
-        disabled: false, // Logic for disabling last item can be added here
+        disabled: false,
         to: record.path
       });
     }
 
-    // Disable the last item
-    const last = items.at(-1);
+    const seen = new Set<string>();
+    const unique = items.filter(item => {
+      const key = `${item.title}|${item.to ?? ''}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    const last = unique.at(-1);
     if (last) last.disabled = true;
 
-    return items;
+    return unique;
   });
 
   return { breadcrumbItems };

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -15,6 +15,9 @@
           :key="(item as any).to || (item as any).title || `it-${index}`"
         >
           <v-divider v-if="item.type === 'divider'" />
+          <v-list-item v-else-if="(item as any).logo" :to="item.to">
+            <img alt="Dina" class="drawer-text-logo" :src="(item as any).logo" />
+          </v-list-item>
           <v-list-item v-else v-bind="item">
             <template #append>
               <v-badge
@@ -268,5 +271,8 @@ onMounted(() => {
 <style scoped>
 .v-navigation-drawer--rail .v-list-subheader span {
   display: none;
+}
+.drawer-text-logo {
+  height: 24px;
 }
 </style>

--- a/frontend/src/services/menu.ts
+++ b/frontend/src/services/menu.ts
@@ -1,11 +1,11 @@
 import type { MenuItem, MenuItemInput } from '@/types/menuData';
-import logo from '@/assets/medina-logo.webp';
+import textLogo from '@/assets/medina-text-logo.webp';
 import { filterMenuByRole } from '@/stores/auth';
 import { Role } from '@/types/auth';
 
 // This is static application configuration, not mock data.
 export const menuData: Readonly<MenuItemInput[]> = [
-  { prependAvatar: logo, title: 'Dina', to: '/' },
+  { logo: textLogo, to: '/' },
   { type: 'divider' },
   { title: 'Messages', prependIcon: 'mdi-message-text-outline', to: '/conversations', roles: [Role.User] },
   { title: 'Notifications', prependIcon: 'mdi-bell-outline', to: '/notifications', roles: [Role.User] },

--- a/frontend/src/types/menuData.ts
+++ b/frontend/src/types/menuData.ts
@@ -9,6 +9,7 @@ interface MenuItemBase {
   link?: boolean;
   roles?: Role[];
   type?: 'divider';
+  logo?: string;
 }
 
 export interface MenuItemInput extends MenuItemBase {


### PR DESCRIPTION
## Summary
- replace Dina text with text logo in navigation and breadcrumbs
- deduplicate breadcrumb segments and map labels
- render logos at consistent size

## Testing
- `npm run lint`
- `npm run build:ci`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68b258819f84833294dae2260f200379